### PR TITLE
In numpy you can no longer index using a boolean, it must be an integ…

### DIFF
--- a/uvotpy/uvotgetspec.py
+++ b/uvotpy/uvotgetspec.py
@@ -2289,7 +2289,7 @@ def interpol(xx,x,y):
       s = (y1[k+1]-y1[k])/(x1[k+1]-x1[k])
       f[i] = y1[k]+s*(xx[q2[0]][i]-x1[k]) 
    f2[q2] = f   
-   f2[not q2] = np.NaN
+   f2[int(not q2)] = np.NaN
    return f2      
 
 


### PR DESCRIPTION
Numpy no longer allows for indexing by a single boolean. This uses an int() to turn the boolean into an integer. It should replicate previous behavior.