### PR TITLE
changing '==None' to 'is None' to fix error

### DIFF
--- a/uvotpy/uvotio.py
+++ b/uvotpy/uvotio.py
@@ -186,7 +186,7 @@ def rate2flux(wave, rate, wheelpos,
    hnu = h_c_ang/(wave)      
    
    # assume uv grism
-   if pixno == None:      
+   if pixno is None:      
       dis = np.arange(len(wave)) - 400  # see uvotgetspec.curved_extraction()
       if spectralorder == 2: dis -= 260
    else:


### PR DESCRIPTION
This error just came up. In uvotio.py there is a statement:
if pixno == None 
which is giving an error that its missing a .any or .all (because when pixno is not None it is an array). This is fixed with 
if pixno is None